### PR TITLE
build: fix missing dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,6 +22,7 @@
     (alcotest-lwt :with-test)
     (httpaf-lwt-unix :with-test)
     (http-lwt-client :with-test)
+    lwt
     cmdliner
     )
   (depopts

--- a/equinoxe.opam
+++ b/equinoxe.opam
@@ -17,6 +17,7 @@ depends: [
   "alcotest-lwt" {with-test}
   "httpaf-lwt-unix" {with-test}
   "http-lwt-client" {with-test}
+  "lwt"
   "cmdliner"
 ]
 depopts: ["http-lwt-client" "piaf"]


### PR DESCRIPTION
Fixing `lwt` dependency if no backend is present.