### PR TITLE
Remove http status code handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,13 @@
 ### Changed
 
 - Rewrite the API using `io` monad (#63, @art-w)
+- Uniform error handling between Cohttp and HLC (#69, @art-w)
 
 ### Removed
 
 - Remove `JSON` module and use `Ezjsonm` directly (#63, @art-w)
 - Remove modules from the old JSON Api module (#68, @maiste)
+- Remove timeout support from Cohttp (#69, @art-w)
 
 ## 0.1.0
 

--- a/src/lib/backend/equinoxe_cohttp.ml
+++ b/src/lib/backend/equinoxe_cohttp.ml
@@ -48,12 +48,8 @@ module Backend = struct
     | `Done v -> Lwt.return v
     | `Timeout -> Lwt.fail_with "Http request timeout"
 
-  let get_body (resp, body) =
-    let code = Cohttp.(Response.status resp |> Code.code_of_status) in
-    if code >= 200 && code < 300 then Cohttp_lwt.Body.to_string body
-    else
-      let msg = Format.sprintf "Cohttp exits with HTTP code %d" code in
-      Lwt.fail_with msg
+  let get_body (_, body) =
+    Cohttp_lwt.Body.to_string body
 
   (**** Http methods ****)
 


### PR DESCRIPTION
The equinix api always returns a json body that contains a description of the error. When we fail on unexpected HTTP status code (not in the 200..300 range), the user looses the information of what failed. I think it's simpler to detect the errors from the json than from the status code (we already don't do that in the hlc backend so it's more uniform that way).

Furthermore, this PR removes the timeout detection from the cohttp backend: again we don't do it in the hlc one, and it's probably better to let the user control when and how the timeout should be done.