### PR TITLE
Convert modules to Friendly_api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,18 +3,19 @@
 ### Added
 
 - Add a Cohttp client version, with a specific package (#60, @maiste)
-- Add Orga module to a statically-typed API (#68, @maiste)
+- Add a statically-typed API (#68, #71, @maiste)
 
 ### Changed
 
 - Rewrite the API using `io` monad (#63, @art-w)
 - Uniform error handling between Cohttp and HLC (#69, @art-w)
+- Update `Equinoxe-cohttp` and `Equinix-hlc` to support only new API (#71, @maiste)
 
 ### Removed
 
 - Remove `JSON` module and use `Ezjsonm` directly (#63, @art-w)
-- Remove modules from the old JSON Api module (#68, @maiste)
 - Remove timeout support from Cohttp (#69, @art-w)
+- Remove old API with JSON from `Equinoxe`, `Equinoxe-cohttp` and `Equinoxe-hlc` (#68, #71, @maiste)
 
 ## 0.1.0
 

--- a/dune-project
+++ b/dune-project
@@ -18,6 +18,7 @@
     (ocaml (>= 4.08.0))
     (ezjsonm (>= 1.3.0))
     (lwt (>= 5.3.0))
+    (odate (>= 0.6))
     (alcotest :with-test)
     (alcotest-lwt :with-test)
     (odoc :with-doc))

--- a/equinoxe.opam
+++ b/equinoxe.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "ezjsonm" {>= "1.3.0"}
   "lwt" {>= "5.3.0"}
+  "odate" {>= "0.6"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
   "odoc" {with-doc}

--- a/examples/example_1.ml
+++ b/examples/example_1.ml
@@ -42,8 +42,8 @@ let get_project_device_id project_id =
 let create_device project_id =
   let open E.Device in
   let builder =
-    build ~plan:C3_small_x86 ~location:Amsterdam ~os:Debian_10
-    |+ Hostname "friendly-api-test"
+    build ~hostname:"friendly-api-test" ~plan:C3_small_x86 ~location:Amsterdam
+      ~os:Debian_10 ()
   in
   let* config = create api ~id:project_id builder in
   Lwt.return config.id

--- a/examples/example_2.ml
+++ b/examples/example_2.ml
@@ -22,7 +22,7 @@
 (*                                                                           *)
 (*****************************************************************************)
 
-module E = Equinoxe.MakeFriendly (Equinoxe_cohttp.Backend)
+module E = Equinoxe_cohttp
 open Lwt.Syntax
 
 let token = "YOUR TOKEN"

--- a/src/bin/devices.ml
+++ b/src/bin/devices.ml
@@ -24,9 +24,10 @@
 
 module Conf = Utils.Conf
 module Json = Utils.Json
-module Equinoxe = Utils.Equinoxe
+module Equinoxe = Utils.Equinoxe_f
 open Cmdliner
 open Utils.Term
+open Utils.Monad
 
 (* Actions *)
 
@@ -36,13 +37,14 @@ let devices_id token meth id =
   match meth with
   | GET ->
       if has_requiered id then
-        let id = Option.get id in
-        Equinoxe.Devices.get_devices_id e ~id () |> Json.pp_r
+        let id = Option.get id |> Equinoxe.Device.id_of_string in
+        let* config = Equinoxe.Device.get_from e ~id in
+        return (Equinoxe.Device.pp config)
       else not_all_requiered_r [ "id" ]
   | DELETE ->
       if has_requiered id then
-        let id = Option.get id in
-        Equinoxe.Devices.delete_devices_id e ~id () |> Json.pp_r
+        let id = Option.get id |> Equinoxe.Device.id_of_string in
+        Equinoxe.Device.delete e ~id ()
       else not_all_requiered_r [ "id" ]
   | meth -> not_supported_r meth "/devices/{id}"
 
@@ -52,8 +54,8 @@ let devices_id_actions token meth id action =
   match meth with
   | POST ->
       if has_requiered id then
-        let id = Option.get id in
-        Equinoxe.Devices.post_devices_id_actions e ~id ~action () |> Json.pp_r
+        let id = Option.get id |> Equinoxe.Device.id_of_string in
+        Equinoxe.Device.execute_action_on e ~id ~action
       else not_all_requiered_r [ "id"; "actions" ]
   | meth -> not_supported_r meth "/devices/{id}/actions"
 
@@ -62,22 +64,13 @@ let devices_id_events token meth id =
   let e = Equinoxe.create ~address ~token () in
   match meth with
   | GET ->
-      if has_requiered id then
-        let id = Option.get id in
-        Equinoxe.Devices.get_devices_id_events e ~id () |> Json.pp_r
+      if has_requiered id then (
+        let id = Option.get id |> Equinoxe.Device.id_of_string in
+        let* events = Equinoxe.Device.get_events_from e ~id in
+        List.iter (fun event -> Equinoxe.Event.pp event) events;
+        return ())
       else not_all_requiered_r [ "id" ]
   | meth -> not_supported_r meth "/devices/{id}/events"
-
-let devices_id_ips token meth id =
-  let address = Conf.address in
-  let e = Equinoxe.create ~address ~token () in
-  match meth with
-  | GET ->
-      if has_requiered id then
-        let id = Option.get id in
-        Equinoxe.Devices.get_devices_id_ips e ~id () |> Json.pp_r
-      else not_all_requiered_r [ "id" ]
-  | meth -> not_supported_r meth "/devices/{id}/ips"
 
 (* Terms *)
 
@@ -116,11 +109,11 @@ let devices_id_actions_t =
     let action =
       Arg.enum
         [
-          ("power_on", Equinoxe.Devices.Power_on);
-          ("power_off", Equinoxe.Devices.Power_off);
-          ("reboot", Equinoxe.Devices.Reboot);
-          ("reinstall", Equinoxe.Devices.Reinstall);
-          ("rescue", Equinoxe.Devices.Rescue);
+          ("power_on", Equinoxe.Device.Power_on);
+          ("power_off", Equinoxe.Device.Power_off);
+          ("reboot", Equinoxe.Device.Reboot);
+          ("reinstall", Equinoxe.Device.Reinstall);
+          ("rescue", Equinoxe.Device.Rescue);
         ]
     in
     Arg.(required & opt (some action) None & info [ "a"; "actions" ] ~doc)
@@ -143,19 +136,4 @@ let devices_id_events_t =
     ( lwt_result (const devices_id_events $ token_t $ meth_t $ id_t),
       info "/devices/id/events" ~doc ~exits ~man )
 
-let devices_id_ips_t =
-  let doc = "Show ips on a specific device" in
-  let exits = default_exits in
-  let man =
-    man_meth ~get:("Retrieve ips on a specific device", [ "id" ], []) ()
-  in
-  let id_t =
-    let doc = "The device id" in
-    Arg.(value & opt (some string) None & info [ "id" ] ~doc)
-  in
-  Term.
-    ( lwt_result (const devices_id_ips $ token_t $ meth_t $ id_t),
-      info "/devices/id/ips" ~doc ~exits ~man )
-
-let t =
-  [ devices_id_t; devices_id_events_t; devices_id_actions_t; devices_id_ips_t ]
+let t = [ devices_id_t; devices_id_events_t; devices_id_actions_t ]

--- a/src/bin/devices.ml
+++ b/src/bin/devices.ml
@@ -23,8 +23,7 @@
 (*****************************************************************************)
 
 module Conf = Utils.Conf
-module Json = Utils.Json
-module Equinoxe = Utils.Equinoxe_f
+module Equinoxe = Utils.Equinoxe
 open Cmdliner
 open Utils.Term
 open Utils.Monad

--- a/src/bin/ips.ml
+++ b/src/bin/ips.ml
@@ -24,9 +24,10 @@
 
 module Conf = Utils.Conf
 module Json = Utils.Json
-module Equinoxe = Utils.Equinoxe
+module Equinoxe = Utils.Equinoxe_f
 open Cmdliner
 open Utils.Term
+open Utils.Monad
 
 (* Actions *)
 
@@ -35,9 +36,11 @@ let ips_id token meth id =
   let e = Equinoxe.create ~address ~token () in
   match meth with
   | GET ->
-      if has_requiered id then
-        let id = Option.get id in
-        Equinoxe.Ip.get_ips_id e ~id () |> Json.pp_r
+      if has_requiered id then (
+        let id = Option.get id |> Equinoxe.Ip.id_of_string in
+        let* ip = Equinoxe.Ip.get_from e ~id in
+        Equinoxe.Ip.pp ip;
+        return ())
       else not_all_requiered_r [ "id" ]
   | meth -> not_supported_r meth "/ips/{id}"
 

--- a/src/bin/ips.ml
+++ b/src/bin/ips.ml
@@ -23,8 +23,7 @@
 (*****************************************************************************)
 
 module Conf = Utils.Conf
-module Json = Utils.Json
-module Equinoxe = Utils.Equinoxe_f
+module Equinoxe = Utils.Equinoxe
 open Cmdliner
 open Utils.Term
 open Utils.Monad

--- a/src/bin/orga.ml
+++ b/src/bin/orga.ml
@@ -23,9 +23,7 @@
 (*****************************************************************************)
 
 module Conf = Utils.Conf
-module Json = Utils.Json
 module Equinoxe = Utils.Equinoxe
-module Equinoxe_f = Utils.Equinoxe_f
 open Cmdliner
 open Utils.Term
 open Utils.Monad
@@ -35,21 +33,21 @@ open Utils.Monad
 let organizations token = function
   | GET ->
       let address = Conf.address in
-      let e = Equinoxe_f.create ~address ~token () in
-      let* organizations = Equinoxe_f.Orga.get_all e in
-      List.iter Equinoxe_f.Orga.pp organizations;
+      let e = Equinoxe.create ~address ~token () in
+      let* organizations = Equinoxe.Orga.get_all e in
+      List.iter Equinoxe.Orga.pp organizations;
       return ()
   | meth -> not_supported_r meth "/organizations"
 
 let organizations_id token meth id =
   let address = Conf.address in
-  let e = Equinoxe_f.create ~address ~token () in
+  let e = Equinoxe.create ~address ~token () in
   match meth with
   | GET ->
       if has_requiered id then (
-        let id = Equinoxe_f.Orga.id_of_string (Option.get id) in
-        let* organization = Equinoxe_f.Orga.get_from e id in
-        Equinoxe_f.Orga.pp organization;
+        let id = Equinoxe.Orga.id_of_string (Option.get id) in
+        let* organization = Equinoxe.Orga.get_from e id in
+        Equinoxe.Orga.pp organization;
         return ())
       else not_all_requiered_r [ "id" ]
   | meth -> not_supported_r meth "/organizations/{id}"

--- a/src/bin/projects.ml
+++ b/src/bin/projects.ml
@@ -24,8 +24,7 @@
 
 module Conf = Utils.Conf
 module Json = Utils.Json
-module Equinoxe = Utils.Equinoxe
-module Equinoxe_f = Utils.Equinoxe_f
+module Equinoxe = Utils.Equinoxe_f
 open Cmdliner
 open Utils.Term
 open Utils.Monad
@@ -40,13 +39,10 @@ let config hostname location plan os =
     && has_requiered os
   then
     Some
-      Equinoxe.Devices.
-        {
-          hostname = Option.get hostname;
-          location = Option.get location;
-          plan = Option.get plan;
-          os = Option.get os;
-        }
+      Equinoxe.Device.(
+        build ~location:(Option.get location) ~plan:(Option.get plan)
+          ~os:(Option.get os)
+        |+ Hostname (Option.get hostname))
   else None
 
 (* Actions *)
@@ -54,21 +50,21 @@ let config hostname location plan os =
 let projects token = function
   | GET ->
       let address = Conf.address in
-      let e = Equinoxe_f.create ~address ~token () in
-      let* projects = Equinoxe_f.Project.get_all e in
-      List.iter Equinoxe_f.Project.pp projects;
+      let e = Equinoxe.create ~address ~token () in
+      let* projects = Equinoxe.Project.get_all e in
+      List.iter Equinoxe.Project.pp projects;
       return ()
   | meth -> not_supported_r meth "/projects"
 
 let projects_id token meth id =
   let address = Conf.address in
-  let e = Equinoxe_f.create ~address ~token () in
+  let e = Equinoxe.create ~address ~token () in
   match meth with
   | GET ->
       if has_requiered id then (
-        let id = Option.get id |> Equinoxe_f.Project.id_of_string in
-        let* project = Equinoxe_f.Project.get_from e ~id in
-        Equinoxe_f.Project.pp project;
+        let id = Option.get id |> Equinoxe.Project.id_of_string in
+        let* project = Equinoxe.Project.get_from e ~id in
+        Equinoxe.Project.pp project;
         return ())
       else not_all_requiered_r [ "id" ]
   | meth -> not_supported_r meth "/projects/{id}"
@@ -78,15 +74,19 @@ let projects_id_devices token meth id config =
   let e = Equinoxe.create ~address ~token () in
   match meth with
   | GET ->
-      if has_requiered id then
-        let id = Option.get id in
-        Equinoxe.Projects.get_projects_id_devices e ~id () |> Json.pp_r
+      if has_requiered id then (
+        let id = Option.get id |> Equinoxe.Project.id_of_string in
+        let* devices = Equinoxe.Device.get_all_from_project e ~id in
+        List.iter (fun device -> Equinoxe.Device.pp device) devices;
+        return ())
       else not_all_requiered_r [ "id" ]
   | POST ->
-      if has_requiered id && has_requiered config then
-        let id = Option.get id in
-        let config = Option.get config in
-        Equinoxe.Projects.post_projects_id_devices e ~id ~config () |> Json.pp_r
+      if has_requiered id && has_requiered config then (
+        let id = Option.get id |> Equinoxe.Project.id_of_string in
+        let builder = Option.get config in
+        let* device = Equinoxe.Device.create e ~id builder in
+        Equinoxe.Device.pp device;
+        return ())
       else not_all_requiered_r [ "id"; "hostname"; "plan"; "facility"; "os" ]
   | meth -> not_supported_r meth "/projects/{id}/devices"
 
@@ -128,7 +128,7 @@ let config_t =
   let plan_t =
     let doc = "The type of server needed" in
     let plan =
-      Equinoxe.Devices.(
+      Equinoxe.Device.(
         Arg.enum
           [
             (plan_to_string C3_small_x86, C3_small_x86);
@@ -140,7 +140,7 @@ let config_t =
   let location_t =
     let doc = "The location where to run the server" in
     let location =
-      Equinoxe.Devices.(
+      Equinoxe.Device.(
         Arg.enum
           [
             (location_to_string Washington, Washington);
@@ -158,7 +158,7 @@ let config_t =
   let os_t =
     let doc = "The operating system of the server" in
     let os =
-      Equinoxe.Devices.(
+      Equinoxe.Device.(
         Arg.enum
           [
             (os_to_string Debian_9, Debian_9);

--- a/src/bin/projects.ml
+++ b/src/bin/projects.ml
@@ -39,9 +39,8 @@ let config hostname location plan os =
   then
     Some
       Equinoxe.Device.(
-        build ~location:(Option.get location) ~plan:(Option.get plan)
-          ~os:(Option.get os)
-        |+ Hostname (Option.get hostname))
+        build ~hostname:(Option.get hostname) ~location:(Option.get location)
+          ~plan:(Option.get plan) ~os:(Option.get os) ())
   else None
 
 (* Actions *)

--- a/src/bin/projects.ml
+++ b/src/bin/projects.ml
@@ -23,8 +23,7 @@
 (*****************************************************************************)
 
 module Conf = Utils.Conf
-module Json = Utils.Json
-module Equinoxe = Utils.Equinoxe_f
+module Equinoxe = Utils.Equinoxe
 open Cmdliner
 open Utils.Term
 open Utils.Monad

--- a/src/bin/user.ml
+++ b/src/bin/user.ml
@@ -24,8 +24,7 @@
 
 module Conf = Utils.Conf
 module Json = Utils.Json
-module Equinoxe = Utils.Equinoxe
-module Equinoxe_f = Utils.Equinoxe_f
+module Equinoxe = Utils.Equinoxe_f
 open Cmdliner
 open Utils.Term
 open Utils.Monad
@@ -35,39 +34,39 @@ open Utils.Monad
 let user token = function
   | GET ->
       let address = Conf.address in
-      let e = Equinoxe_f.create ~address ~token () in
-      let* users = Equinoxe_f.Users.get_current_user e in
-      Equinoxe_f.Users.pp users;
+      let e = Equinoxe.create ~address ~token () in
+      let* users = Equinoxe.User.get_current_user e in
+      Equinoxe.User.pp users;
       return ()
   | meth -> not_supported_r meth "/user"
 
 let user_api_keys token meth description write =
   let address = Conf.address in
-  let e = Equinoxe_f.create ~address ~token () in
+  let e = Equinoxe.create ~address ~token () in
   match meth with
   | GET ->
-      let* keys = Equinoxe_f.Auth.get_keys e in
-      List.iter Equinoxe_f.Auth.pp keys;
+      let* keys = Equinoxe.Auth.get_keys e in
+      List.iter Equinoxe.Auth.pp keys;
       return ()
   | POST ->
       let read_only = not write in
       let has_requiered = has_requiered description in
       let description = Option.get description in
       if has_requiered then (
-        let* req = Equinoxe_f.Auth.create_key e ~read_only ~description () in
-        Equinoxe_f.Auth.pp req;
+        let* req = Equinoxe.Auth.create_key e ~read_only ~description () in
+        Equinoxe.Auth.pp req;
         return ())
       else not_all_requiered_r [ "description" ]
   | meth -> not_supported_r meth "/user/api-keys"
 
 let user_api_keys_id token meth id =
   let address = Conf.address in
-  let e = Equinoxe_f.create ~address ~token () in
+  let e = Equinoxe.create ~address ~token () in
   match meth with
   | DELETE ->
       if has_requiered id then
-        let id = Option.get id |> Equinoxe_f.Auth.id_of_string in
-        Equinoxe_f.Auth.delete_key e ~id
+        let id = Option.get id |> Equinoxe.Auth.id_of_string in
+        Equinoxe.Auth.delete_key e ~id
       else not_all_requiered_r [ "id" ]
   | meth -> not_supported_r meth "/user/api-keys"
 

--- a/src/bin/user.ml
+++ b/src/bin/user.ml
@@ -23,8 +23,7 @@
 (*****************************************************************************)
 
 module Conf = Utils.Conf
-module Json = Utils.Json
-module Equinoxe = Utils.Equinoxe_f
+module Equinoxe = Utils.Equinoxe
 open Cmdliner
 open Utils.Term
 open Utils.Monad

--- a/src/bin/utils.ml
+++ b/src/bin/utils.ml
@@ -25,14 +25,7 @@
 open Cmdliner
 
 (* Import module and create Equinoxe from Ezcurl. *)
-module Equinoxe = Equinoxe_hlc.Api
-module Equinoxe_f = Equinoxe_hlc.Friendly_api
-
-module Json = struct
-  let pp json = Format.printf "%s" (Ezjsonm.value_to_string ~minify:false json)
-  let pp_r m = Lwt_result.map pp m
-  let to_unit m = Lwt_result.map (fun _ -> ()) m
-end
+module Equinoxe = Equinoxe_hlc
 
 module Monad = struct
   let ( let* ) m f = Equinoxe_hlc.Backend.bind f m

--- a/src/lib/backend/equinoxe_cohttp.ml
+++ b/src/lib/backend/equinoxe_cohttp.ml
@@ -59,5 +59,4 @@ module Backend = struct
     compute ~headers ~url @@ fun ~headers ~url -> Client.delete ~headers url
 end
 
-module Api = Equinoxe.Make (Backend)
-module Friendly_api = Equinoxe.MakeFriendly (Backend)
+include Equinoxe.Make (Backend)

--- a/src/lib/backend/equinoxe_cohttp.mli
+++ b/src/lib/backend/equinoxe_cohttp.mli
@@ -27,8 +27,5 @@
 module Backend : Equinoxe.Backend with type 'a io = 'a Lwt.t
 (** @inline *)
 
-module Api : Equinoxe.API with type 'a io = 'a Lwt.t
-(** @inline *)
-
-module Friendly_api : Equinoxe.FRIENDLY_API with type 'a io = 'a Lwt.t
+include Equinoxe.API with type 'a io = 'a Lwt.t
 (** @inline *)

--- a/src/lib/backend/equinoxe_hlc.ml
+++ b/src/lib/backend/equinoxe_hlc.ml
@@ -22,12 +22,10 @@
 (*                                                                           *)
 (*****************************************************************************)
 
-type 'a io = ('a, [ `Msg of string ]) Lwt_result.t
-
 module Client = Http_lwt_client
 
 module Backend = struct
-  type nonrec 'a io = 'a io
+  type nonrec 'a io = ('a, [ `Msg of string ]) Lwt_result.t
 
   let return = Lwt_result.return
   let map = Lwt_result.map
@@ -58,5 +56,4 @@ module Backend = struct
     get_body =<< Client.one_request ~meth:`DELETE ~headers url
 end
 
-module Api = Equinoxe.Make (Backend)
-module Friendly_api = Equinoxe.MakeFriendly (Backend)
+include Equinoxe.Make (Backend)

--- a/src/lib/backend/equinoxe_hlc.mli
+++ b/src/lib/backend/equinoxe_hlc.mli
@@ -24,13 +24,8 @@
 
 (** It provides an API call system relying on {!Http_lwt_client}. *)
 
-type 'a io = ('a, [ `Msg of string ]) Lwt_result.t
-
-module Backend : Equinoxe.Backend with type 'a io = 'a io
+module Backend : Equinoxe.Backend with type 'a io = ('a, [ `Msg of string ]) Lwt_result.t
 (** @inline *)
 
-module Api : Equinoxe.API with type 'a io = 'a io
-(** @inline *)
-
-module Friendly_api : Equinoxe.FRIENDLY_API with type 'a io = 'a io
+include Equinoxe.API with type 'a io = ('a, [ `Msg of string ]) Lwt_result.t
 (** @inline *)

--- a/src/lib/equinoxe/dune
+++ b/src/lib/equinoxe/dune
@@ -1,4 +1,4 @@
 (library
  (name equinoxe)
  (public_name equinoxe)
- (libraries ezjsonm unix lwt))
+ (libraries ezjsonm odate unix lwt))

--- a/src/lib/equinoxe/equinoxe.ml
+++ b/src/lib/equinoxe/equinoxe.ml
@@ -61,12 +61,15 @@ module Make (B : Backend) : API with type 'a io = 'a B.io = struct
     in
     fail msg
 
-  let raise_wrong_date ~name json =
-    raise
-      (Ezjsonm.Parse_error
-         (json, Format.sprintf "%s: Date.Parser.from_iso can't parse date" name))
-
   let replace_empty s = if s = "" then "<empty>" else s
+
+  let get_date ~name parsable_string =
+    try Date.Parser.from_iso parsable_string
+    with Failure _ ->
+      raise
+        (Ezjsonm.Parse_error
+           ( `String parsable_string,
+             Format.sprintf "%s: Date.Parser.from_iso can't parse date" name ))
 
   module Http = struct
     let url ~t ~path = Filename.concat t.address path
@@ -189,22 +192,20 @@ module Make (B : Backend) : API with type 'a io = 'a B.io = struct
     let id_of_string id = id
 
     let config_of_json json =
-      try
-        {
-          id = access "id" json |> Ezjsonm.get_string;
-          first_name = access "first_name" json |> Ezjsonm.get_string;
-          last_name = access "last_name" json |> Ezjsonm.get_string;
-          email = access "email" json |> Ezjsonm.get_string;
-          created_at =
-            access "create_at" json
-            |> Ezjsonm.get_string
-            |> Date.Parser.from_iso;
-          last_login_at =
-            access "last_login_at" json
-            |> Ezjsonm.get_string
-            |> Date.Parser.from_iso;
-        }
-      with Failure _ -> raise_wrong_date ~name:"User.config_of_json" json
+      {
+        id = access "id" json |> Ezjsonm.get_string;
+        first_name = access "first_name" json |> Ezjsonm.get_string;
+        last_name = access "last_name" json |> Ezjsonm.get_string;
+        email = access "email" json |> Ezjsonm.get_string;
+        created_at =
+          access "create_at" json
+          |> Ezjsonm.get_string
+          |> get_date ~name:"User.config_of_json";
+        last_login_at =
+          access "last_login_at" json
+          |> Ezjsonm.get_string
+          |> get_date ~name:"User.config_of_json";
+      }
 
     let to_string config =
       let created_at = Date.Printer.to_iso config.created_at in
@@ -247,18 +248,16 @@ module Make (B : Backend) : API with type 'a io = 'a B.io = struct
     let id_of_string id = id
 
     let config_of_json json =
-      try
-        {
-          id = access "id" json |> Ezjsonm.get_string;
-          token = access "token" json |> Ezjsonm.get_string;
-          read_only = access "read_only" json |> Ezjsonm.get_bool;
-          created_at =
-            access "created_at" json
-            |> Ezjsonm.get_string
-            |> Date.Parser.from_iso;
-          description = access "description" json |> Ezjsonm.get_string;
-        }
-      with Failure _ -> raise_wrong_date ~name:"Auth.config_of_json" json
+      {
+        id = access "id" json |> Ezjsonm.get_string;
+        token = access "token" json |> Ezjsonm.get_string;
+        read_only = access "read_only" json |> Ezjsonm.get_bool;
+        created_at =
+          access "created_at" json
+          |> Ezjsonm.get_string
+          |> get_date ~name:"Auth.config_of_json";
+        description = access "description" json |> Ezjsonm.get_string;
+      }
 
     let to_string config =
       let created_at = Date.Printer.to_iso config.created_at in
@@ -340,21 +339,19 @@ module Make (B : Backend) : API with type 'a io = 'a B.io = struct
         config.public config.enabled created_at
 
     let config_of_json json =
-      try
-        {
-          id = access "id" json |> Ezjsonm.get_string;
-          netmask = access "netmask" json |> Ezjsonm.get_string;
-          network = access "network" json |> Ezjsonm.get_string;
-          address = access "address" json |> Ezjsonm.get_string;
-          gateway = access "gateway" json |> Ezjsonm.get_string;
-          public = access "public" json |> Ezjsonm.get_bool;
-          enabled = access "enabled" json |> Ezjsonm.get_bool;
-          created_at =
-            access "created_at" json
-            |> Ezjsonm.get_string
-            |> Date.Parser.from_iso;
-        }
-      with Failure _ -> raise_wrong_date ~name:"Ip.config_of_json" json
+      {
+        id = access "id" json |> Ezjsonm.get_string;
+        netmask = access "netmask" json |> Ezjsonm.get_string;
+        network = access "network" json |> Ezjsonm.get_string;
+        address = access "address" json |> Ezjsonm.get_string;
+        gateway = access "gateway" json |> Ezjsonm.get_string;
+        public = access "public" json |> Ezjsonm.get_bool;
+        enabled = access "enabled" json |> Ezjsonm.get_bool;
+        created_at =
+          access "created_at" json
+          |> Ezjsonm.get_string
+          |> get_date ~name:"Ip.config_of_json";
+      }
 
     let get_from t ~id =
       let path = Filename.concat "ips" id in
@@ -380,20 +377,18 @@ module Make (B : Backend) : API with type 'a io = 'a B.io = struct
     let string_of_id id = id
 
     let config_of_json json =
-      try
-        {
-          id = access "id" json |> Ezjsonm.get_string;
-          name = access "name" json |> Ezjsonm.get_string;
-          created_at =
-            access "created_at" json
-            |> Ezjsonm.get_string
-            |> Date.Parser.from_iso;
-          updated_at =
-            access "updated_at" json
-            |> Ezjsonm.get_string
-            |> Date.Parser.from_iso;
-        }
-      with Failure _ -> raise_wrong_date ~name:"Project.config_of_json" json
+      {
+        id = access "id" json |> Ezjsonm.get_string;
+        name = access "name" json |> Ezjsonm.get_string;
+        created_at =
+          access "created_at" json
+          |> Ezjsonm.get_string
+          |> get_date ~name:"Project.config_of_json";
+        updated_at =
+          access "updated_at" json
+          |> Ezjsonm.get_string
+          |> get_date ~name:"Project.config_of_json";
+      }
 
     let to_string config =
       let created_at = Date.Printer.to_iso config.created_at in
@@ -466,18 +461,16 @@ module Make (B : Backend) : API with type 'a io = 'a B.io = struct
     }
 
     let t_of_json json =
-      try
-        {
-          id = access "id" json |> Ezjsonm.get_string;
-          state = access "state" json |> Ezjsonm.get_string |> State.of_string;
-          event_type = access "type" json |> Ezjsonm.get_string;
-          body = access "body" json |> Ezjsonm.get_string;
-          created_at =
-            access "created_at" json
-            |> Ezjsonm.get_string
-            |> Date.Parser.from_iso;
-        }
-      with Failure _ -> raise_wrong_date ~name:"Event.t_of_json" json
+      {
+        id = access "id" json |> Ezjsonm.get_string;
+        state = access "state" json |> Ezjsonm.get_string |> State.of_string;
+        event_type = access "type" json |> Ezjsonm.get_string;
+        body = access "body" json |> Ezjsonm.get_string;
+        created_at =
+          access "created_at" json
+          |> Ezjsonm.get_string
+          |> get_date ~name:"Event.t_of_json";
+      }
 
     let to_string t =
       let created_at = Date.Printer.to_iso t.created_at in
@@ -626,36 +619,34 @@ module Make (B : Backend) : API with type 'a io = 'a B.io = struct
         try access "ip_addresses" json |> Ezjsonm.get_list Ip.config_of_json
         with _ -> []
       in
-      try
-        {
-          id = access "id" json |> Ezjsonm.get_string;
-          hostname = access "hostname" json |> Ezjsonm.get_string;
-          location =
-            access "metro" json
-            |> access "code"
-            |> Ezjsonm.get_string
-            |> String.uppercase_ascii
-            |> location_of_string;
-          plan =
-            access "plan" json
-            |> access "slug"
-            |> Ezjsonm.get_string
-            |> plan_of_string;
-          os =
-            access "operating_system" json
-            |> access "slug"
-            |> Ezjsonm.get_string
-            |> os_of_string;
-          state = access "state" json |> Ezjsonm.get_string |> State.of_string;
-          tags = access "tags" json |> Ezjsonm.get_list Ezjsonm.get_string;
-          user = access "user" json |> Ezjsonm.get_string;
-          created_at =
-            access "created_at" json
-            |> Ezjsonm.get_string
-            |> Date.Parser.from_iso;
-          ips;
-        }
-      with Failure _ -> raise_wrong_date ~name:"Device.config_of_json" json
+      {
+        id = access "id" json |> Ezjsonm.get_string;
+        hostname = access "hostname" json |> Ezjsonm.get_string;
+        location =
+          access "metro" json
+          |> access "code"
+          |> Ezjsonm.get_string
+          |> String.uppercase_ascii
+          |> location_of_string;
+        plan =
+          access "plan" json
+          |> access "slug"
+          |> Ezjsonm.get_string
+          |> plan_of_string;
+        os =
+          access "operating_system" json
+          |> access "slug"
+          |> Ezjsonm.get_string
+          |> os_of_string;
+        state = access "state" json |> Ezjsonm.get_string |> State.of_string;
+        tags = access "tags" json |> Ezjsonm.get_list Ezjsonm.get_string;
+        user = access "user" json |> Ezjsonm.get_string;
+        created_at =
+          access "created_at" json
+          |> Ezjsonm.get_string
+          |> get_date ~name:"Device.config_of_json";
+        ips;
+      }
 
     let to_string config =
       let location = location_to_string config.location in

--- a/src/lib/equinoxe/equinoxe.ml
+++ b/src/lib/equinoxe/equinoxe.ml
@@ -184,7 +184,7 @@ struct
     let pp config = Format.printf "%s\n" (to_string config)
   end
 
-  module Users = struct
+  module User = struct
     type id = string
 
     type config = {
@@ -488,9 +488,25 @@ struct
             |> Date.Parser.from_iso;
         }
       with Failure _ -> raise_wrong_date ~name:"Event.t_of_json" json
+
+    let to_string t =
+      let created_at = Date.Printer.to_iso t.created_at in
+      Format.sprintf
+        "{\n\
+         \tid: %s;\n\
+         \tstate: %s;\n\
+         \ttype: %s;\n\
+         \tbody: %s;\n\
+         \tcreated_at: %s;\n\
+         }"
+        (replace_empty t.id) (State.to_string t.state)
+        (replace_empty t.event_type)
+        (replace_empty t.body) created_at
+
+    let pp t = Format.printf "%s\n" (to_string t)
   end
 
-  module Devices = struct
+  module Device = struct
     type id = string
 
     let id_of_string id = id
@@ -589,7 +605,7 @@ struct
 
     type setter = Hostname of string
 
-    let build plan os location = { hostname = None; plan; os; location }
+    let build ~plan ~os ~location = { hostname = None; plan; os; location }
 
     let set_builder builder = function
       | Hostname hostname -> { builder with hostname = Some hostname }

--- a/src/lib/equinoxe/equinoxe.ml
+++ b/src/lib/equinoxe/equinoxe.ml
@@ -235,6 +235,8 @@ struct
         (Ezjsonm.Parse_error
            (json, Format.sprintf "access: field %s not found" field))
 
+  let replace_empty s = if s = "" then "<empty>" else s
+
   module Http = struct
     let url ~t ~path = Filename.concat t.address path
 
@@ -303,7 +305,6 @@ struct
       }
 
     let to_string config =
-      let pp_empty s = if s = "" then "<empty>" else s in
       Format.sprintf
         "{\n\
          \tname: %s;\n\
@@ -312,11 +313,12 @@ struct
          \twebsite: %s;\n\
          \tmaintenance_email: %s;\n\
          \tmax_projects: %d;\n\
-         }\n"
-        (pp_empty config.id)
-        (pp_empty config.account_id)
-        (pp_empty config.name) (pp_empty config.website)
-        (pp_empty config.maintenance_email)
+         }"
+        (replace_empty config.id)
+        (replace_empty config.account_id)
+        (replace_empty config.name)
+        (replace_empty config.website)
+        (replace_empty config.maintenance_email)
         config.max_projects
 
     let get_from t id =
@@ -348,7 +350,7 @@ struct
         in
         fail msg
 
-    let pp config = Format.printf "%s" (to_string config)
+    let pp config = Format.printf "%s\n" (to_string config)
   end
 
   module Users = struct
@@ -387,7 +389,6 @@ struct
              (json, Format.sprintf "Date.Parser.from_iso: can't parse date"))
 
     let to_string config =
-      let replace_empty s = if s = "" then "<empty>" else s in
       let created_at = Date.Printer.to_iso config.created_at in
       let last_login_at = Date.Printer.to_iso config.last_login_at in
       Format.sprintf
@@ -398,7 +399,7 @@ struct
          \temail: %s;\n\
          \tcreate_at: %s;\n\
          \tlast_login_at: %s;\n\
-         }\n"
+         }"
         (replace_empty config.id)
         (replace_empty config.first_name)
         (replace_empty config.last_name)

--- a/src/lib/equinoxe/equinoxe.ml
+++ b/src/lib/equinoxe/equinoxe.ml
@@ -593,14 +593,8 @@ module Make (B : Backend) : API with type 'a io = 'a B.io = struct
       location : location;
     }
 
-    type setter = Hostname of string
-
-    let build ~plan ~os ~location = { hostname = None; plan; os; location }
-
-    let set_builder builder = function
-      | Hostname hostname -> { builder with hostname = Some hostname }
-
-    let ( |+ ) = set_builder
+    let build ?hostname ~plan ~os ~location () =
+      { hostname; plan; os; location }
 
     let builder_to_json builder =
       `O

--- a/src/lib/equinoxe/equinoxe.ml
+++ b/src/lib/equinoxe/equinoxe.ml
@@ -26,16 +26,6 @@ include Equinoxe_intf
 
 (* Functor to build API using a specific call API system. *)
 module Make (B : Backend) : API with type 'a io = 'a B.io = struct
-  type json = Ezjsonm.value
-  type 'a io = 'a B.io
-  type t = { address : string; token : string }
-
-  let create ?(address = "https://api.equinix.com/metal/v1/") ?(token = "") () =
-    { address; token }
-end
-
-module MakeFriendly (B : Backend) : FRIENDLY_API with type 'a io = 'a B.io =
-struct
   type 'a io = 'a B.io
   type t = { address : string; token : string }
 

--- a/src/lib/equinoxe/equinoxe_intf.ml
+++ b/src/lib/equinoxe/equinoxe_intf.ml
@@ -152,14 +152,10 @@ module type API = sig
     (** [post_projects_id_devicest ~id ~config ()] creates a machine on the
         Equinix with the {!Devices.config} specification *)
   end
-
-  module Users : sig
-    (** This module manages API parts related to users. *)
-
-    val get_user : t -> json io
-    (** [get_user t] returns information about the user linked to the API key. *)
-  end
 end
+
+module Date = ODate.Unix
+(** Module to manipulate dates in the API. *)
 
 module type FRIENDLY_API = sig
   (** It offers OCaml types to manipulate the Equinix API. *)
@@ -207,6 +203,35 @@ module type FRIENDLY_API = sig
 
     val pp : config -> unit
     (** [pp config] pretty-prints an organization configuration. *)
+  end
+
+  module Users : sig
+    (** A module to interact with Equinix users. *)
+
+    type id
+    (** A unique identifier for a user. *)
+
+    type config = {
+      id : id;
+      first_name : string;
+      last_name : string;
+      email : string;
+      created_at : Date.t;
+      last_login_at : Date.t;
+    }
+    (** Representation of a user configuration. *)
+
+    val id_of_string : string -> id
+    (* [id_of_string str] creates an id from a string from the Equinix API. *)
+
+    val to_string : config -> string
+    (** [to_string config] returns a string representing a user. *)
+
+    val get_current_user : t -> config io
+    (** [get_current_user t] returns the user interacting with the API. *)
+
+    val pp : config -> unit
+    (** [pp config] pretty-prints a user configuration. *)
   end
 end
 

--- a/src/lib/equinoxe/equinoxe_intf.ml
+++ b/src/lib/equinoxe/equinoxe_intf.ml
@@ -22,25 +22,10 @@
 (*                                                                           *)
 (*****************************************************************************)
 
-module type API = sig
-  (** @deprecated It is the signature that matches the API of the website. *)
-
-  type 'a io
-  type json = Ezjsonm.value
-
-  type t
-  (** Abstract type [t] represents the information known by the API system. *)
-
-  val create : ?address:string -> ?token:string -> unit -> t
-  (** [create ~address ~token ()] returns an {!t} object, you need to manipulate
-      when executing requests. Default [address] is
-      [https://api.equinix.com/metal/v1/] and default [token] is empty. *)
-end
-
 module Date = ODate.Unix
 (** Module to manipulate dates in the API. *)
 
-module type FRIENDLY_API = sig
+module type API = sig
   (** It offers OCaml types to manipulate the Equinix API. *)
 
   type 'a io
@@ -403,17 +388,12 @@ module type Sigs = sig
   (** Equinoxe library interface. *)
 
   module type API = API
-  module type FRIENDLY_API = FRIENDLY_API
 
   (** {1 Build your own API} *)
 
   module type Backend = Backend
 
-  (** Factory to build a system to communicate with Equinix API, using the
-      {!Backend} communication system. *)
-  module Make (B : Backend) : API with type 'a io = 'a B.io
-
   (** Factory to build a system to communicate with Equinix API in a
       strongly-typed way using the {!Backend} gathering system. *)
-  module MakeFriendly (B : Backend) : FRIENDLY_API with type 'a io = 'a B.io
+  module Make (B : Backend) : API with type 'a io = 'a B.io
 end

--- a/src/lib/equinoxe/equinoxe_intf.ml
+++ b/src/lib/equinoxe/equinoxe_intf.ml
@@ -36,22 +36,6 @@ module type API = sig
       when executing requests. Default [address] is
       [https://api.equinix.com/metal/v1/] and default [token] is empty. *)
 
-  module Auth : sig
-    (** This module manages API parts related to authentification. *)
-
-    val get_user_api_keys : t -> json io
-    (** [get_user_api_keys t] returns the keys available for the current user. *)
-
-    val post_user_api_keys :
-      t -> ?read_only:bool -> description:string -> unit -> json io
-    (** [post_user_api_keys t ~read_only ~description ()] creates a new API key
-        on Equinix. Default value to read_only is true. *)
-
-    val delete_user_api_keys_id : t -> id:string -> unit -> json io
-    (** [delete_user_api_keys_id t ~id () ] deletes the key referenced by [id]
-        from the user keys. *)
-  end
-
   module Devices : sig
     (** This module manages API parts related to devices. *)
 
@@ -232,6 +216,43 @@ module type FRIENDLY_API = sig
 
     val pp : config -> unit
     (** [pp config] pretty-prints a user configuration. *)
+  end
+
+  module Auth : sig
+    (** This module manages API parts related to authentification. *)
+
+    type id
+    (** Unique identifier to represent a key in the Equinix API *)
+
+    type config = {
+      id : id;
+      token : string;
+      read_only : bool;
+      created_at : Date.t;
+      description : string;
+    }
+    (** Representation of an API key *)
+
+    val id_of_string : string -> id
+    (** [id_of_string str] returns a unique identifier from the Equinix API *)
+
+    val to_string : config -> string
+    (** [to_string config] returns a string representating an API key. *)
+
+    val get_keys : t -> config list io
+    (** [get_keys t] returns the keys available for the current user. *)
+
+    val create_key :
+      t -> ?read_only:bool -> description:string -> unit -> config io
+    (** [create_key t ~read_only ~description ()] creates a new API key on
+        Equinix. Default value to read_only is true. *)
+
+    val delete_key : t -> id:id -> unit io
+    (** [delete_key t ~id () ] deletes the key referenced by [id] from the user
+        keys. *)
+
+    val pp : config -> unit
+    (** [pp config] prints on stdout the [config] given. *)
   end
 end
 

--- a/src/lib/equinoxe/equinoxe_intf.ml
+++ b/src/lib/equinoxe/equinoxe_intf.ml
@@ -109,14 +109,6 @@ module type API = sig
         ips. *)
   end
 
-  module Ip : sig
-    (** This module manages API parts related to ips. *)
-
-    val get_ips_id : t -> id:string -> unit -> json io
-    (** [get_ips_id t ~id ()] returns informations about an ip referenced by its
-        [id]. *)
-  end
-
   module Projects : sig
     (** This module manages API parts related to projects. *)
 
@@ -248,11 +240,43 @@ module type FRIENDLY_API = sig
         Equinix. Default value to read_only is true. *)
 
     val delete_key : t -> id:id -> unit io
-    (** [delete_key t ~id () ] deletes the key referenced by [id] from the user
+    (** [delete_key t ~id ] deletes the key referenced by [id] from the user
         keys. *)
 
     val pp : config -> unit
     (** [pp config] prints on stdout the [config] given. *)
+  end
+
+  module Ip : sig
+    (** This module manages API parts related to ips. *)
+
+    type id
+    (** Abstract to represent a unique identifier in the Equinix API. *)
+
+    type config = {
+      id : id;
+      netmask : string;
+      network : string;
+      address : string;
+      gateway : string;
+      public : bool;
+      enabled : bool;
+      created_at : Date.t;
+    }
+    (** Representation of an Ip configuration. *)
+
+    val id_of_string : string -> id
+    (** [id_of_string str] turns a string into an Ip [id]. *)
+
+    val to_string : config -> string
+    (** [to_string config] returns a string that represents the configuration. *)
+
+    val get_from : t -> id:id -> config io
+    (** [get_ips_id t ~id] returns informations about an ip referenced by its
+        [id]. *)
+
+    val pp : config -> unit
+    (** [pp config] prints a [config] in a human readable way. *)
   end
 end
 

--- a/src/lib/equinoxe/equinoxe_intf.ml
+++ b/src/lib/equinoxe/equinoxe_intf.ml
@@ -39,14 +39,14 @@ module type API = sig
       [https://api.equinix.com/metal/v1/] and default [token] is empty. *)
 
   exception Unknown_value of string * string
-  (** This exception represent an error when the parsing works but the value
+  (** This exception represents an error when parsing works but the value
       received is unknown. *)
 
   module Orga : sig
     (** A module to interact with Equinix organization. *)
 
     type id
-    (** The unique indentifier for the an organization. *)
+    (** The unique identifier for the an organization. *)
 
     type config = {
       id : id;
@@ -78,7 +78,7 @@ module type API = sig
   end
 
   module User : sig
-    (** A module to interact with Equinix users. *)
+    (** A module to interact with Equinix user. *)
 
     type id
     (** A unique identifier for a user. *)
@@ -110,7 +110,7 @@ module type API = sig
     (** This module manages API parts related to authentification. *)
 
     type id
-    (** Unique identifier to represent a key in the Equinix API *)
+    (** Unique identifier to represent a key in the Equinix API. *)
 
     type config = {
       id : id;
@@ -119,10 +119,10 @@ module type API = sig
       created_at : Date.t;
       description : string;
     }
-    (** Representation of an API key *)
+    (** Representation of an API key config. *)
 
     val id_of_string : string -> id
-    (** [id_of_string str] returns a unique identifier from the Equinix API *)
+    (** [id_of_string str] returns a unique identifier from the Equinix API. *)
 
     val to_string : config -> string
     (** [to_string config] returns a string representating an API key. *)
@@ -136,7 +136,7 @@ module type API = sig
         Equinix. Default value to read_only is true. *)
 
     val delete_key : t -> id:id -> unit io
-    (** [delete_key t ~id ] deletes the key referenced by [id] from the user
+    (** [delete_key t ~id] deletes the key referenced by [id] from the user
         keys. *)
 
     val pp : config -> unit
@@ -147,7 +147,8 @@ module type API = sig
     (** This module manages API parts related to ips. *)
 
     type id
-    (** Abstract to represent a unique identifier in the Equinix API. *)
+    (** Abstract type to represent a unique identifier in the Equinix API for
+        ip. *)
 
     type config = {
       id : id;
@@ -229,14 +230,14 @@ module type API = sig
 
     val of_string : string -> t
     (** [of_string str] returns a state in function of a string. If the state is
-        not known, it returns Unknown_state. *)
+        not known, it raises an {!Unknown_value} exception. *)
 
     val to_string : t -> string
     (** [to_string t] returns a string representation of the state. *)
   end
 
   module Event : sig
-    (** This module deals with events that occures in Equinix. *)
+    (** This module deals with events that occure in Equinix. *)
 
     type id
     (** Unique identifier. *)
@@ -257,13 +258,14 @@ module type API = sig
     (** A representation of an event. *)
 
     val t_of_json : Ezjsonm.value -> t
-    (** [t_of_json json] extracts information about event from [json]. *)
+    (** [t_of_json json] extracts information about event from [json]. If the
+        parsing fails, it raises an {!Ezjsonm.Parse_error} exception. *)
 
     val to_string : t -> string
     (** [to_string t] returns a string representation of [t]. *)
 
     val pp : t -> unit
-    (** [pp t] print in human readable way the [t] value. *)
+    (** [pp t] prints in a human readable way the [t] value. *)
   end
 
   module Device : sig
@@ -309,8 +311,8 @@ module type API = sig
       | Sydney
 
     val location_to_string : location -> string
-    (** [location_to_string facility] converts a facility into a string
-        understandable by the API. *)
+    (** [location_to_string metro] converts a metro into a string understandable
+        by the API. *)
 
     (** Server type when deploying a new device. *)
     type plan = C3_small_x86 | C3_medium_x86
@@ -329,7 +331,7 @@ module type API = sig
       location:location ->
       unit ->
       builder
-    (* [build plan os locatation] returns a build with the minimal configuration required. *)
+    (* [build ~hostname ~plan ~os ~locatation ()] returns a build with the minimal configuration required. *)
 
     type config = {
       id : id;
@@ -350,30 +352,29 @@ module type API = sig
     (** [to_string config] returns a readable string containing the config. *)
 
     val get_from : t -> id:id -> config io
-    (** [get_devices_id t ~id ()] returns a {!config} that contains information
-        about the device specified by [id]. *)
+    (** [get_from t t ~id] returns a {!config} that contains information about
+        the device specified by [id]. *)
 
     val get_events_from : t -> id:id -> Event.t list io
-    (** [get_device_id_events t ~id ()] retrieves information about the device
-        events. *)
+    (** [get_events_from t ~id] retrieves information about the device events. *)
 
     val execute_action_on : t -> id:id -> action:action -> unit io
-    (** [post_devices_id_actions t ~id ~action ()] executes an action on the
-        device specified by its id. *)
+    (** [execute_action_on t ~id ~action] executes an action on the device
+        specified by its id. *)
 
     val delete : t -> id:id -> ?force:bool -> unit -> unit io
-    (** [delete_devices_id t ~id ~force ()] deletes a device on Equinix and
-        returns a {!json} with the result. [?force] defaults to [false], if
-        [true] then it forces the deletion of the device by detaching any
-        storage volume still active. *)
+    (** [delete t ~id ~force ()] deletes a device on Equinix and returns a
+        {!json} with the result. [?force] defaults to [false], if [true] then it
+        forces the deletion of the device by detaching any storage volume still
+        active. *)
 
     val create : t -> id:Project.id -> builder -> config io
-    (** [post_projects_id_devicest ~id ~config ()] creates a machine on the
-        Equinix with the {!Devices.config} specification. *)
+    (** [create t ~id builder] creates a machine on the Equinix with the
+        {!Devices.builder} specification. *)
 
     val get_all_from_project : t -> id:Project.id -> config list io
-    (** [get_projects_id_devices t ~id] returns the {!json} that contains all
-        the devices related to the project [id]. *)
+    (** [get_all_from_project t ~id] returns the {!config} list that contains
+        all the devices related to the project [id]. *)
 
     val pp : config -> unit
     (** [pp config] prints a readable string representing the config. *)

--- a/src/lib/equinoxe/equinoxe_intf.ml
+++ b/src/lib/equinoxe/equinoxe_intf.ml
@@ -322,15 +322,13 @@ module type API = sig
     type builder
     (** This type represents the configuration wanted for a device. *)
 
-    type setter = Hostname of string  (** Option to extend the builder. *)
-
-    val set_builder : builder -> setter -> builder
-    (** [set_builder builder setter] extends the builder with the option. *)
-
-    val ( |+ ) : builder -> setter -> builder
-    (** [builder |+ setter] is an infix operator for {!set_builder}. *)
-
-    val build : plan:plan -> os:os -> location:location -> builder
+    val build :
+      ?hostname:string ->
+      plan:plan ->
+      os:os ->
+      location:location ->
+      unit ->
+      builder
     (* [build plan os locatation] returns a build with the minimal configuration required. *)
 
     type config = {

--- a/src/lib/equinoxe/equinoxe_intf.ml
+++ b/src/lib/equinoxe/equinoxe_intf.ml
@@ -112,21 +112,18 @@ module type API = sig
   module Projects : sig
     (** This module manages API parts related to projects. *)
 
-    val get_projects : t -> json io
-    (** [get_projects t] returns all projects associated with the token. *)
-
-    val get_projects_id : t -> id:string -> unit -> json io
-    (** [get_projects_id t ~id ()] returns the {!json} that is referenced by the
-        [id] given in parameter. *)
-
-    val get_projects_id_devices : t -> id:string -> unit -> json io
-    (** [get_projects_id_devices t ~id ()] returns the {!json} that contains all
-        the devices related to the project [id]. *)
-
     val post_projects_id_devices :
       t -> id:string -> config:Devices.config -> unit -> json io
     (** [post_projects_id_devicest ~id ~config ()] creates a machine on the
-        Equinix with the {!Devices.config} specification *)
+        Equinix with the {!Devices.config} specification
+
+        TODO: move to Device module in friendly_api! *)
+
+    val get_projects_id_devices : t -> id:string -> unit -> json io
+    (** [get_projects_id_devices t ~id ()] returns the {!json} that contains all
+        the devices related to the project [id].
+
+        TODO: same as post_projects_id_devices! *)
   end
 end
 
@@ -277,6 +274,40 @@ module type FRIENDLY_API = sig
 
     val pp : config -> unit
     (** [pp config] prints a [config] in a human readable way. *)
+  end
+
+  module Project : sig
+    (** This module manages API parts related to projects. *)
+
+    type id
+    (** Unique identifier for the Equinix API. *)
+
+    type config = {
+      id : id;
+      name : string;
+      created_at : Date.t;
+      updated_at : Date.t;
+    }
+    (** Representation of an Equinix Project. *)
+
+    val id_of_string : string -> id
+    (** [id_of_string str] converts [str] into an [id]. *)
+
+    val string_of_id : id -> string
+    (** [string_of_id id] returns the string that represents the [id]. *)
+
+    val to_string : config -> string
+    (** [to_string config] returns a string representation of the [config]. *)
+
+    val get_all : t -> config list io
+    (** [get_all t] returns all projects associated with the token. *)
+
+    val get_from : t -> id:id -> config io
+    (** [get_from t ~id ] returns the {!config} of the project that is
+        referenced by the [id] given in parameter. *)
+
+    val pp : config -> unit
+    (** [pp config] prints a human readable Project config. *)
   end
 end
 

--- a/src/lib/equinoxe/equinoxe_intf.ml
+++ b/src/lib/equinoxe/equinoxe_intf.ml
@@ -92,7 +92,7 @@ module type FRIENDLY_API = sig
     (** [pp config] pretty-prints an organization configuration. *)
   end
 
-  module Users : sig
+  module User : sig
     (** A module to interact with Equinix users. *)
 
     type id
@@ -273,9 +273,15 @@ module type FRIENDLY_API = sig
 
     val t_of_json : Ezjsonm.value -> t
     (** [t_of_json json] extracts information about event from [json]. *)
+
+    val to_string : t -> string
+    (** [to_string t] returns a string representation of [t]. *)
+
+    val pp : t -> unit
+    (** [pp t] print in human readable way the [t] value. *)
   end
 
-  module Devices : sig
+  module Device : sig
     (** This module manages API parts related to devices. *)
 
     type id
@@ -339,7 +345,7 @@ module type FRIENDLY_API = sig
     val ( |+ ) : builder -> setter -> builder
     (** [builder |+ setter] is an infix operator for {!set_builder}. *)
 
-    val build : plan -> os -> location -> builder
+    val build : plan:plan -> os:os -> location:location -> builder
     (* [build plan os locatation] returns a build with the minimal configuration required. *)
 
     type config = {


### PR DESCRIPTION
This is the main part of the job to convert `Raw` JSON to typed structures. The last commit should remove the `Api` and the `Friendly_api` module as discussed in #68.

- [X] Users
- [x] Auth
- [x] Ips
- [x] Projects
- [x] Devices
