### PR TITLE
Introduce IPXE constructor in Equinoxe

### DIFF
--- a/src/equinoxe/equinoxe_intf.ml
+++ b/src/equinoxe/equinoxe_intf.ml
@@ -294,6 +294,7 @@ module type API = sig
       | FreeBSD_11_2
       | Centos_8
       | Alpine_3
+      | Custom_ipxe of string
 
     val os_to_string : os -> string
     (** [os_to_string os] converts an os into a string understandable by the


### PR DESCRIPTION
This PR introduces the iPXE mechanism into Equinoxe to allow network booting.

The `url` parameter must refer to an`.ipxe` script.